### PR TITLE
Kernel/Memory: Add virtual memory allocation.

### DIFF
--- a/Kernel/Kernel.cpp
+++ b/Kernel/Kernel.cpp
@@ -90,5 +90,13 @@ extern "C" void kernel_main(void *page_tables_base_ptr)
 
     memory_manager.enable_paging();
 
-    vga.write_string("Enabled paging !\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+    char *ptr = (char *)kernel_vm.allocate_virtual_memory(NULL, PAGE_SIZE, 0);
+
+    if (ptr == NULL)
+        vga.write_string("Error in memory allocation!\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+    else {
+        for (int i = 0; i < PAGE_SIZE; i++)
+            ptr[i] = 0xff;
+        vga.write_string("Successfully allocated memory !\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+    }
 }

--- a/Kernel/Memory/VirtualMemoryManager.cpp
+++ b/Kernel/Memory/VirtualMemoryManager.cpp
@@ -1,4 +1,5 @@
 #include <Kernel/Memory/VirtualMemoryManager.hpp>
+#include <User/Libc/Libc.hpp>
 
 namespace Memory
 {
@@ -27,11 +28,40 @@ namespace Memory
         }
     }
 
-    void    *VirtualMemoryManager::allocate_virtual_memory_page(void *addr, uint64_t len, int prot)
+    void    *VirtualMemoryManager::allocate_virtual_memory(void *addr, uint64_t len, int prot)
     {
-        (void)len;
+        // TODO: let user allocate memory at a specified virtual address.
+        // TODO: let user define the protection flags.
+
+        (void)addr;
         (void)prot;
-        return addr;
+        void *first_page_ptr = NULL;
+
+        // We allocate by multiples of (PAGE_SIZE), so here we will round up (len) to the next multiple of (PAGE_SIZE).
+        len = PhysicalMemoryManager::find_aligned_address(len, PAGE_SIZE);
+
+        for (; len > 0; len -= PAGE_SIZE)
+        {
+            // Page table in current page directory entry is full, use the page table in the next page directory entry.
+            if (page_directory.page_table_info[page_directory_size - 1].size >= PAGE_TABLE_SIZE)
+                page_directory_size++;
+
+            uint16_t page_directory_index = page_directory_size - 1;
+            uint16_t page_table_index = page_directory.page_table_info[page_directory_index].size;
+
+            const MemoryPage *page = memory_manager.allocate_physical_memory_page();
+
+            PageTableEntry pt_entry;
+            pt_entry.set_present()->set_read_write()->set_u_s()->set_pwt()->set_cache_disbled()->set_physical_address(page->get_base_addr());
+
+            PageDirectoryEntry *pde_entry = page_directory.page_directory[page_directory_index];
+            PageTable          *page_table = (PageTable *)(pde_entry->page_table_address << 12);
+            page_table->add_new_entry(pt_entry, page_table_index);
+            page_directory.page_table_info[page_directory_index].size++;
+            if (first_page_ptr == NULL)
+                first_page_ptr = (void *)construct_virtual_address(page_directory_index, page_table_index, 0x0);
+        }
+        return (first_page_ptr);
     }
 
     uint32_t     VirtualMemoryManager::construct_virtual_address(uint16_t directory_index, uint16_t table_index, uint16_t offset)

--- a/Kernel/Memory/VirtualMemoryManager.hpp
+++ b/Kernel/Memory/VirtualMemoryManager.hpp
@@ -17,7 +17,7 @@ namespace Memory
             VirtualMemoryManager(void *page_tables_ptr);
 
         public:
-            void                *allocate_virtual_memory_page(void *addr, uint64_t len, int prot);
+            void                *allocate_virtual_memory(void *addr, uint64_t len, int prot);
             static uint32_t     construct_virtual_address(uint16_t directory_index, uint16_t table_index, uint16_t offset);
             void                load_page_directory(void);
             void                insert_page_directory_entry(PagingStructureEntry *entry);


### PR DESCRIPTION
Add a method in the VirtualMemoryManager to allocate virtual memory, we can allocate memory depending on the len argument (round up to `PAGE_SIZE`), however we don't have the ability to allocate memory in specified address passed as argument just yet, we also don't let the user define the protection flags.