### PR TITLE
Kernel/Memory: add page table entry bookkeeping.

### DIFF
--- a/Kernel/Boot.s
+++ b/Kernel/Boot.s
@@ -11,11 +11,11 @@
 .long FLAGS
 .long CHECKSUM
 
-/* Initializing a 16 KiB memory area we will use as a stack */
+/* Initializing a 1 MiB memory area we will use as a stack */
 .section .bss
 .align 16
 stack_bottom:
-.skip 1024 * 26
+.skip 1079296
 stack_top:
 
 /*

--- a/Kernel/Kernel.cpp
+++ b/Kernel/Kernel.cpp
@@ -99,7 +99,7 @@ extern "C" void kernel_main(void *kernel_page_tables, void *user_page_tables)
     else
     {
         memory_manager.print_uallocated_memory_pages(vga, 0);
-        user_vm.free_virtual_memory(ptr, PAGE_SIZE * 3);
+        user_vm.free_virtual_memory(ptr, PAGE_SIZE * 4);
         memory_manager.print_ufree_memory_pages(vga, 0);
         memory_manager.print_uallocated_memory_pages(vga, 0);
     }

--- a/Kernel/Memory/PageTable.hpp
+++ b/Kernel/Memory/PageTable.hpp
@@ -16,6 +16,7 @@ namespace Memory
     struct PageTableInfo
     {
         uint16_t size;
+        bool entry_used[N_PAGE_TABLE_ENTRIES];
     };
 
     struct PageTable

--- a/Kernel/Memory/UserVirtualMemoryManager.cpp
+++ b/Kernel/Memory/UserVirtualMemoryManager.cpp
@@ -44,6 +44,7 @@ namespace Memory
             PageDirectoryEntry *pde_entry = page_directory.page_directory[page_directory_index];
             PageTable          *page_table = (PageTable *)(pde_entry->page_table_address << 12);
             page_table->add_new_entry(pt_entry, page_table_index);
+            page_directory.page_table_info[page_directory_index].entry_used[page_table_index] = true;
             page_directory.page_table_info[page_directory_index].size++;
             if (first_page_ptr == NULL)
                 first_page_ptr = (void *)construct_virtual_address(page_directory_index, page_table_index, 0x0);
@@ -66,10 +67,14 @@ namespace Memory
             TranslatedLinearAddress translated_address = TranslatedLinearAddress::get_translated_address(addr);
             if (page_directory.page_directory[translated_address.page_directory_index] != NULL)
             {
-                PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->page_table_address << 12);
-                uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].page_table_address << 12);
-                memory_manager.ufree_physical_memory_page(MemoryPage(physical_address));
-                page_directory.page_table_info[translated_address.page_directory_index].size--;
+                if (page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] == true)
+                {
+                    PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->page_table_address << 12);
+                    uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].page_table_address << 12);
+                    memory_manager.ufree_physical_memory_page(MemoryPage(physical_address));
+                    page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] = false;
+                    page_directory.page_table_info[translated_address.page_directory_index].size--;
+                }
             }
             addr = (void *)(((uint8_t *)addr) + PAGE_SIZE);
         }


### PR DESCRIPTION
Add an array of PageTableInfo to store information about each page table referenced by each page directory entry.

This commit alone increased the stack usage by 1 MiB.