### PR TITLE
Kernel/Memory: implement null pointers.

### DIFF
--- a/Kernel/Kernel.cpp
+++ b/Kernel/Kernel.cpp
@@ -90,17 +90,13 @@ extern "C" void kernel_main(void *kernel_page_tables, void *user_page_tables)
 
     kernel_vm.load_page_directory();
 
+    // Disable first page so de-refrencing a NULL ptr would not work.
+    int ret = kernel_vm.disable_page(0x0, PAGE_SIZE);
+
     memory_manager.enable_paging();
 
-    void *ptr = user_vm.allocate_virtual_memory(NULL, PAGE_SIZE * 3, 0);
-
-    if (ptr == NULL)
-        vga.write_string("Error allocating virtual memory\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+    if (ret == -1)
+        vga.write_string("Error in disabling page (0x0)\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
     else
-    {
-        memory_manager.print_uallocated_memory_pages(vga, 0);
-        user_vm.free_virtual_memory(ptr, PAGE_SIZE * 4);
-        memory_manager.print_ufree_memory_pages(vga, 0);
-        memory_manager.print_uallocated_memory_pages(vga, 0);
-    }
+        vga.write_string("Disabling page (0x0) succeeded\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
 }

--- a/Kernel/Memory/KernelVirtualMemoryManager.cpp
+++ b/Kernel/Memory/KernelVirtualMemoryManager.cpp
@@ -39,10 +39,10 @@ namespace Memory
             const MemoryPage *page = memory_manager.kallocate_physical_memory_page();
 
             PageTableEntry pt_entry;
-            pt_entry.set_present()->set_read_write()->set_u_s()->set_pwt()->set_cache_disbled()->set_physical_address(page->get_base_addr());
+            pt_entry.set_present(true)->set_read_write(true)->set_u_s(true)->set_pwt(true)->set_cache_disbled(true)->set_physical_address(page->get_base_addr());
 
             PageDirectoryEntry *pde_entry = page_directory.page_directory[page_directory_index];
-            PageTable          *page_table = (PageTable *)(pde_entry->page_table_address << 12);
+            PageTable          *page_table = (PageTable *)(pde_entry->physical_address << 12);
             page_table->add_new_entry(pt_entry, page_table_index);
             page_directory.page_table_info[page_directory_index].size++;
             page_directory.page_table_info[page_directory_index].entry_used[page_table_index] = true;
@@ -69,8 +69,8 @@ namespace Memory
             {
                 if (page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_directory_index] == true)
                 {
-                    PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->page_table_address << 12);
-                    uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].page_table_address << 12);
+                    PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->physical_address << 12);
+                    uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].physical_address << 12);
                     memory_manager.kfree_physical_memory_page(MemoryPage(physical_address));
                     page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] = false;
                     page_directory.page_table_info[translated_address.page_directory_index].size--;

--- a/Kernel/Memory/PagingStructureEntry.cpp
+++ b/Kernel/Memory/PagingStructureEntry.cpp
@@ -2,58 +2,58 @@
 
 namespace Memory
 {
-    PagingStructureEntry *PagingStructureEntry::set_present(void)
+    PagingStructureEntry *PagingStructureEntry::set_present(bool value)
     {
-        this->present = 1;
+        this->present = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_read_write(void)
+    PagingStructureEntry *PagingStructureEntry::set_read_write(bool value)
     {
-        this->read_write = 1;
+        this->read_write = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_u_s(void)
+    PagingStructureEntry *PagingStructureEntry::set_u_s(bool value)
     {
-        this->u_s = 1;
+        this->u_s = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_pwt(void)
+    PagingStructureEntry *PagingStructureEntry::set_pwt(bool value)
     {
-        this->pwt = 1;
+        this->pwt = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_cache_disbled(void)
+    PagingStructureEntry *PagingStructureEntry::set_cache_disbled(bool value)
     {
-        this->cache_disbled = 1;
+        this->cache_disbled = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_page_size(void)
+    PagingStructureEntry *PagingStructureEntry::set_page_size(bool value)
     {
-        this->pat = 1;
+        this->pat = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_pat(void)
+    PagingStructureEntry *PagingStructureEntry::set_pat(bool value)
     {
-        this->pat = 1;
+        this->pat = value;
         return this;
     }
 
-    PagingStructureEntry *PagingStructureEntry::set_global(void)
+    PagingStructureEntry *PagingStructureEntry::set_global(bool value)
     {
-        this->global = 1;
+        this->global = value;
         return this;
     }
 
     PagingStructureEntry *PagingStructureEntry::set_physical_address(uint32_t physical_address)
     {
         // Address should be 4K page aligned.
-        this->page_table_address = physical_address >> 12;
+        this->physical_address = physical_address >> 12;
         return this;
     }
 }

--- a/Kernel/Memory/PagingStructureEntry.hpp
+++ b/Kernel/Memory/PagingStructureEntry.hpp
@@ -71,16 +71,16 @@ namespace Memory
         /*
             Physical address of the page table (4K bytes alligned).
         */
-        uint32_t page_table_address : 20;
+        uint32_t physical_address : 20;
 
-        PagingStructureEntry *set_present(void);
-        PagingStructureEntry *set_read_write(void);
-        PagingStructureEntry *set_u_s(void);
-        PagingStructureEntry *set_pwt(void);
-        PagingStructureEntry *set_cache_disbled(void);
-        PagingStructureEntry *set_page_size(void);
-        PagingStructureEntry *set_pat(void);
-        PagingStructureEntry *set_global(void);
+        PagingStructureEntry *set_present(bool value);
+        PagingStructureEntry *set_read_write(bool value);
+        PagingStructureEntry *set_u_s(bool value);
+        PagingStructureEntry *set_pwt(bool value);
+        PagingStructureEntry *set_cache_disbled(bool value);
+        PagingStructureEntry *set_page_size(bool value);
+        PagingStructureEntry *set_pat(bool value);
+        PagingStructureEntry *set_global(bool value);
         PagingStructureEntry *set_physical_address(uint32_t physical_address);
     } PSE;
 

--- a/Kernel/Memory/UserVirtualMemoryManager.cpp
+++ b/Kernel/Memory/UserVirtualMemoryManager.cpp
@@ -39,10 +39,10 @@ namespace Memory
             const MemoryPage *page = memory_manager.uallocate_physical_memory_page();
 
             PageTableEntry pt_entry;
-            pt_entry.set_present()->set_read_write()->set_u_s()->set_pwt()->set_cache_disbled()->set_physical_address(page->get_base_addr());
+            pt_entry.set_present(true)->set_read_write(true)->set_u_s(true)->set_pwt(true)->set_cache_disbled(true)->set_physical_address(page->get_base_addr());
 
             PageDirectoryEntry *pde_entry = page_directory.page_directory[page_directory_index];
-            PageTable          *page_table = (PageTable *)(pde_entry->page_table_address << 12);
+            PageTable          *page_table = (PageTable *)(pde_entry->physical_address << 12);
             page_table->add_new_entry(pt_entry, page_table_index);
             page_directory.page_table_info[page_directory_index].entry_used[page_table_index] = true;
             page_directory.page_table_info[page_directory_index].size++;
@@ -69,8 +69,8 @@ namespace Memory
             {
                 if (page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] == true)
                 {
-                    PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->page_table_address << 12);
-                    uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].page_table_address << 12);
+                    PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->physical_address << 12);
+                    uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].physical_address << 12);
                     memory_manager.ufree_physical_memory_page(MemoryPage(physical_address));
                     page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] = false;
                     page_directory.page_table_info[translated_address.page_directory_index].size--;

--- a/Kernel/Memory/VirtualMemoryManager.hpp
+++ b/Kernel/Memory/VirtualMemoryManager.hpp
@@ -32,6 +32,7 @@ namespace Memory
             void                load_page_directory(void);
             void                insert_page_directory_entry(PagingStructureEntry *entry);
             void                identity_map_memory(uint64_t virtual_address_start, uint64_t virtual_address_end);
+            int                 disable_page(const void *virtual_address, uint32_t len);
 
         private:
             void                 identity_map_memory_page(uint64_t virtual_address);


### PR DESCRIPTION
Disable page 0x0 in the kernel virtual address space so dereferencing a NULL pointer will cause a page fault.
