### PR TITLE
Kernel/Memory: fix free memory bug.

### DIFF
--- a/Kernel/Kernel.cpp
+++ b/Kernel/Kernel.cpp
@@ -102,6 +102,7 @@ extern "C" void kernel_main(void *kernel_page_tables, void *user_page_tables)
     void *ptr = kernel_vm.allocate_virtual_memory(NULL, PAGE_SIZE, 0);
     if (ptr != NULL)
     {
+        kernel_vm.free_virtual_memory(ptr, PAGE_SIZE);
         memcpy(ptr, str, strlen(str) + 1);
         vga.write_string((char *)ptr, VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
     } else

--- a/Kernel/Memory/KernelVirtualMemoryManager.cpp
+++ b/Kernel/Memory/KernelVirtualMemoryManager.cpp
@@ -1,4 +1,5 @@
 #include <Kernel/Memory/KernelVirtualMemoryManager.hpp>
+#include <string.h>
 
 namespace Memory
 {
@@ -79,13 +80,14 @@ namespace Memory
             TranslatedLinearAddress translated_address = TranslatedLinearAddress::get_translated_address(addr);
             if (page_directory.page_directory[translated_address.page_directory_index] != NULL)
             {
-                if (page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_directory_index] == true)
+                if (page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] == true)
                 {
                     PageTable *page_table = (PageTable *)(page_directory.page_directory[translated_address.page_directory_index]->physical_address << 12);
                     uint32_t physical_address = (page_table->page_table[translated_address.page_table_index].physical_address << 12);
                     memory_manager.kfree_physical_memory_page(MemoryPage(physical_address));
                     page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] = false;
                     page_directory.page_table_info[translated_address.page_directory_index].size--;
+                    memset(&(page_table->page_table[translated_address.page_table_index]), 0x0, sizeof(PageTableEntry));
                 }
             }
             addr = (void *)(((uint8_t *)addr) + PAGE_SIZE);

--- a/Kernel/Memory/UserVirtualMemoryManager.cpp
+++ b/Kernel/Memory/UserVirtualMemoryManager.cpp
@@ -1,4 +1,5 @@
 #include <Kernel/Memory/UserVirtualMemoryManager.hpp>
+#include <string.h>
 
 namespace Memory
 {
@@ -86,6 +87,7 @@ namespace Memory
                     memory_manager.ufree_physical_memory_page(MemoryPage(physical_address));
                     page_directory.page_table_info[translated_address.page_directory_index].entry_used[translated_address.page_table_index] = false;
                     page_directory.page_table_info[translated_address.page_directory_index].size--;
+                    memset(&(page_table->page_table[translated_address.page_table_index]), 0x0, sizeof(PageTableEntry));
                 }
             }
             addr = (void *)(((uint8_t *)addr) + PAGE_SIZE);


### PR DESCRIPTION
Fix a bug where i use the page directory index instead of page table index to see if an page table entry is used.

Memset a page table entry to 0x0 when freeing a page so we won't access the old values in in the future.