### PR TITLE
Kernel/Memory: improve virtual memory allocation.

### DIFF
--- a/Kernel/Kernel.cpp
+++ b/Kernel/Kernel.cpp
@@ -60,7 +60,7 @@ extern "C" void kernel_main(void *kernel_page_tables, void *user_page_tables)
     uint32_t                               mmap_length = multiboot_info_ptr->mmap_length;
     multiboot_mmap                         *mmap_addr = multiboot_info_ptr->mmap_addr;
     uint32_t                               mmap_structure_size;
-    const char                             *str = "Allocated kernel memory successfully !\n";
+    const char                             *str = "Allocated memory successfully !\n";
 
     // Setup physical memory regions in the memory manager.
     for (uint32_t i = 0; i < mmap_length; i += mmap_structure_size + 4)
@@ -94,15 +94,15 @@ extern "C" void kernel_main(void *kernel_page_tables, void *user_page_tables)
 
     kernel_vm.load_page_directory();
 
+    memory_manager.enable_paging();
+
     // Disable first page so de-refrencing a NULL ptr would not work.
     kernel_vm.disable_page(0x0, PAGE_SIZE);
 
-    memory_manager.enable_paging();
-
     void *ptr = kernel_vm.allocate_virtual_memory(NULL, PAGE_SIZE, 0);
+
     if (ptr != NULL)
     {
-        kernel_vm.free_virtual_memory(ptr, PAGE_SIZE);
         memcpy(ptr, str, strlen(str) + 1);
         vga.write_string((char *)ptr, VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
     } else

--- a/Kernel/Memory/KernelVirtualMemoryManager.cpp
+++ b/Kernel/Memory/KernelVirtualMemoryManager.cpp
@@ -17,8 +17,8 @@ namespace Memory
     {
         // TODO: let user allocate memory at a specified virtual address.
         // TODO: let user define the protection flags.
-
         VGA::TEXT_MODE &vga = VGA::TEXT_MODE::instantiate();
+
         (void)addr;
         (void)prot;
         void *first_page_ptr = NULL;
@@ -29,33 +29,41 @@ namespace Memory
         else
             len = PhysicalMemoryManager::find_aligned_address(len, PAGE_SIZE);
 
+        uint16_t page_directory_index;
+        uint16_t page_table_index;
+    
+        if (page_directory.find_contiguous_free_pages(len / PAGE_SIZE, page_directory_index, page_table_index) == false)
+        {
+            vga.write_string("KernelVirtualMemoryManager::allocate_virtual_memory: failed to allocate virtual memory page.\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+            return NULL;
+        }
+
         for (; len > 0; len -= PAGE_SIZE)
         {
-            // Page table in current page directory entry is full, use the page table in the next page directory entry.
-            if (page_directory.page_table_info[page_directory_size - 1].size >= PAGE_TABLE_SIZE)
-                page_directory_size++;
-
-            uint16_t page_directory_index = page_directory_size - 1;
-            uint16_t page_table_index = page_directory.page_table_info[page_directory_index].size;
-
             const MemoryPage *page = memory_manager.kallocate_physical_memory_page();
             if (page == NULL)
             {
-                vga.write_string("KernelVirtualMemoryManager::allocate_virtual_memory: failed to allocate physical memory page.\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::GREEN, VGA::BLINK::FALSE);
+                vga.write_string("KernelVirtualMemoryManager::allocate_virtual_memory: failed to allocate physical memory page.\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
                 return NULL;
             }
-            PageTableEntry pt_entry;
-            pt_entry.set_present(true)->set_read_write(true)->set_u_s(true)->set_pwt(true)->set_cache_disbled(true)->set_physical_address(page->get_base_addr());
 
             PageDirectoryEntry *pde_entry = page_directory.page_directory[page_directory_index];
             if (pde_entry == NULL)
+            {
+                vga.write_string("KernelVirtualMemoryManager::allocate_virtual_memory: such page directory.\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
                 return NULL;
+            }
             PageTable          *page_table = (PageTable *)(pde_entry->physical_address << 12);
+
+            PageTableEntry pt_entry;
+            pt_entry.set_present(true)->set_read_write(true)->set_u_s(true)->set_pwt(true)->set_cache_disbled(true)->set_physical_address(page->get_base_addr());
+
             page_table->add_new_entry(pt_entry, page_table_index);
-            page_directory.page_table_info[page_directory_index].size++;
-            page_directory.page_table_info[page_directory_index].entry_used[page_table_index] = true;
             if (first_page_ptr == NULL)
                 first_page_ptr = (void *)construct_virtual_address(page_directory_index, page_table_index, 0x0);
+            page_directory.page_table_info[page_directory_index].entry_used[page_table_index] = true;
+            page_directory.page_table_info[page_directory_index].size++;
+            page_table_index++;
         }
         return (first_page_ptr);
     }
@@ -66,7 +74,7 @@ namespace Memory
 
         if (addr == NULL || PhysicalMemoryManager::find_aligned_address((uint64_t)addr, PAGE_SIZE) != (uint64_t)addr)
         {
-            vga.write_string("KernelVirtualMemoryManager::free_virtual_memory: Virtual address is not page aligned\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::GREEN, VGA::BLINK::FALSE);
+            vga.write_string("KernelVirtualMemoryManager::free_virtual_memory: Virtual address is not page aligned\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
             return -1;
         }
 

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -1,6 +1,8 @@
 #include <Kernel/Memory/PageDirectory.hpp>
 
 #include <stdint.h>
+#include <Kernel/VGA/VGA.hpp>
+#include <string.h>
 
 namespace Memory
 {
@@ -10,5 +12,60 @@ namespace Memory
             return NULL;
         this->page_directory[index] = entry;
         return (this->page_directory[index]);
+    }
+
+    int16_t                    PageDirectory::find_free_page_table(uint16_t n_entries, uint16_t offset)
+    {
+        uint16_t free_page_table_index = offset;
+
+        for (; free_page_table_index < page_directory_size; free_page_table_index++)
+        {
+            uint16_t empty_entries = N_PAGE_TABLE_ENTRIES - page_table_info[free_page_table_index].size;
+            if (empty_entries >= n_entries)
+                return free_page_table_index;
+        }
+
+        return -1;
+    }
+
+    // FIXME: this will look for (number_of_pages) contiguous empty entries in the same page table,
+    // however we can use contiguous empty entries from two different (contiguous) page tables.
+    bool        PageDirectory::find_contiguous_free_pages(uint16_t number_of_pages, uint16_t &page_directory_index, uint16_t &page_table_index)
+    {
+        uint16_t offset = 0;
+        int16_t free_page_table_index;
+
+        // Find (number_of_pages) contiguous empty entries.
+        while ((free_page_table_index = find_free_page_table(number_of_pages, offset)) != -1)
+        {
+            offset = free_page_table_index + 1;
+            int16_t first_entry = -1;
+            uint16_t n_pages_found = 0;
+
+            for (uint16_t i = 0; i < N_PAGE_DIRECTORY_ENTRIES; i++)
+            {
+                if (n_pages_found == number_of_pages)
+                    break;
+                if (page_table_info[free_page_table_index].entry_used[i] == false)
+                {
+                    n_pages_found++;
+                    if (first_entry == -1)
+                        first_entry = i;
+                }
+                else
+                {
+                    first_entry = -1;
+                    n_pages_found = 0;
+                }
+            }
+
+            if (n_pages_found == number_of_pages)
+            {
+                page_directory_index = free_page_table_index;
+                page_table_index = first_entry;
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Kernel/Memory/PageDirectory.hpp
+++ b/Kernel/Memory/PageDirectory.hpp
@@ -22,6 +22,10 @@ namespace Memory
             Use this to keep information about the page table referenced in [page_directory].
         */
         PageTableInfo               page_table_info[N_PAGE_DIRECTORY_ENTRIES];
+        uint16_t                    page_directory_size;
+        uint16_t                    current_index;
         const PagingStructureEntry  *add_new_entry(PagingStructureEntry *entry, uint16_t index);
+        int16_t                     find_free_page_table(uint16_t n_entries, uint16_t offset);
+        bool                        find_contiguous_free_pages(uint16_t number_of_pages, uint16_t &page_directory_index, uint16_t &page_table_index);
     };
 }

--- a/Kernel/Memory/VirtualMemoryManager.hpp
+++ b/Kernel/Memory/VirtualMemoryManager.hpp
@@ -35,11 +35,11 @@ namespace Memory
             int                         disable_page(const void *virtual_address, uint32_t len);
 
         private:
-            void                 identity_map_memory_page(uint64_t virtual_address);
+            void                    identity_map_memory_page(uint64_t virtual_address);
+            void                    find_free_page_table_entries(uint16_t number_of_pages, uint16_t &page_directory_index, uint16_t &page_table_index);
 
         protected:
             PhysicalMemoryManager &memory_manager = PhysicalMemoryManager::instantiate();
             PageDirectory         page_directory;
-            uint16_t              page_directory_size;
     };
 }


### PR DESCRIPTION
When allocating virtual memory we used to keep an index of the last page directory entry and use it to get a page table address, this implementation does not make any sense and it worked by chance.

Now I have added some methods to look for free page tables that we can use to allocate our virtual memory.