### PR TITLE
Kernel/Memory: refactor virtual memory code.

### DIFF
--- a/Kernel/Kernel.cpp
+++ b/Kernel/Kernel.cpp
@@ -99,12 +99,13 @@ extern "C" void kernel_main(void *kernel_page_tables, void *user_page_tables)
     // Disable first page so de-refrencing a NULL ptr would not work.
     kernel_vm.disable_page(0x0, PAGE_SIZE);
 
-    void *ptr = kernel_vm.allocate_virtual_memory(NULL, PAGE_SIZE, 0);
-
+    void *ptr = kernel_vm.kmalloc(PAGE_SIZE);
+    
     if (ptr != NULL)
     {
-        memcpy(ptr, str, strlen(str) + 1);
-        vga.write_string((char *)ptr, VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+        size_t size = kernel_vm.ksize(ptr);
+        vga.write_string(itoa(size), VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
+        vga.write_string("\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
     } else
         vga.write_string("Allocation failed\n", VGA::BG_COLOR::BG_BLACK, VGA::FG_COLOR::RED, VGA::BLINK::FALSE);
 }

--- a/Kernel/Memory/KernelVirtualMemoryManager.hpp
+++ b/Kernel/Memory/KernelVirtualMemoryManager.hpp
@@ -11,7 +11,8 @@ namespace Memory
             KernelVirtualMemoryManager(void *page_tables_ptr);
 
         public:
-            void                                            *allocate_virtual_memory(void *addr, uint64_t len, int prot);
-            int                                             free_virtual_memory(void *addr, uint64_t len);
+            void                                            *kmalloc(size_t len);
+            int                                             kfree(void *addr, size_t len);
+            size_t                                          ksize(const void *addr);
     };
 }

--- a/Kernel/Memory/UserVirtualMemoryManager.hpp
+++ b/Kernel/Memory/UserVirtualMemoryManager.hpp
@@ -11,7 +11,8 @@ namespace Memory
             UserVirtualMemoryManager(void *page_tables_ptr);
 
         public:
-            void                                            *allocate_virtual_memory(void *addr, uint64_t len, int prot);
-            int                                             free_virtual_memory(void *addr, uint64_t len);
+            void                                            *vmalloc(size_t len);
+            int                                             vfree(void *addr, size_t len);
+            size_t                                          vsize(const void *addr);
     };
 }

--- a/Kernel/Memory/VirtualMemoryManager.hpp
+++ b/Kernel/Memory/VirtualMemoryManager.hpp
@@ -26,8 +26,6 @@ namespace Memory
             VirtualMemoryManager(void *page_tables_ptr);
 
         public:
-            virtual void                *allocate_virtual_memory(void *addr, uint64_t len, int prot) = 0;
-            virtual int                 free_virtual_memory(void *addr, uint64_t len) = 0;
             static uint32_t             construct_virtual_address(uint16_t directory_index, uint16_t table_index, uint16_t offset);
             void                        load_page_directory(void);
             const PagingStructureEntry  *insert_page_directory_entry(PagingStructureEntry *entry);


### PR DESCRIPTION
Change the methods in the virtual memory manager for both user and kernel to resemble the linux kernel, however they do not work the same as the linux kernel.

vmalloc, vfree, vsize for virtual memory for user space.
kmalloc, kfree, ksize for virtual memory for kernel space.